### PR TITLE
chore: ignore path for CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+ - 'test/projects/broken/**/*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,19 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches:
+      - master
+      - v*
+  pull_request:
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          config-file: ./.github/codeql-config.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - v*
+  pull_request:
 
 permissions: read-all
 


### PR DESCRIPTION
Ignore broken file for CodeQL. See https://github.com/simple-icons/svglint/security/code-scanning/tools/CodeQL/status/configurations/automatic/c4476d61850e12a69f9b7e3bfc5486372eefda10dd14f27df5d189056a453063