### PR TITLE
fix: change the incorrect `return` to `break` for order rule

### DIFF
--- a/src/rules/attr.js
+++ b/src/rules/attr.js
@@ -96,7 +96,7 @@ function executeOnElm($elm, config, reporter, ast) {
 				const index = order.indexOf(attributes[i]);
 				if (index === -1) {
 					// This attribute doesn't need ordering, ignore it
-					return;
+					break;
 				}
 
 				if (previousIndex !== -1 && index < previousIndex) {

--- a/test/attr.spec.js
+++ b/test/attr.spec.js
@@ -174,4 +174,15 @@ describe('Rule: attr', () => {
 			'rule::whitelist': true,
 			'rule::order': true,
 		}));
+	it.only('should fail customizing ordering with whitelist', () =>
+		testFailsFactory(
+			testSVG.replace('viewBox="0 0 24 24"', 'viewBox="0 0 24 24" foo="bar"'),
+			'attr',
+		)({
+			role: true,
+			viewBox: true,
+			'rule::selector': 'svg',
+			'rule::whitelist': true,
+			'rule::order': ['role', 'viewBox'],
+		}));
 });


### PR DESCRIPTION
Fixes #126