### PR TITLE
Update NPM releasing to OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write # to create a GitHub Release
       issues: write # to comment on issues included in a release
       pull-requests: write # to comment on Pull Requests included in a release
-      id-token: write # to generate npm provenance statements
+      id-token: write # to generate npm provenance statements and allow OIDC auth
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,5 +28,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "prepublishOnly": "rollup -c",
     "test": "mocha --timeout 10000"
   },
-  "publishConfig": {
-    "provenance": true
-  },
   "dependencies": {
     "ansi-regex": "^6.1.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
Resolves #130

- The npm token revoked by birjj (explained it in the linked issue) has been removed from release.yml and from actions' secrets.
- Provenance statements are automatically generated when publishing via OIDC authentication. See [_Automatic Provenance Generation_ in the npm documentation](https://docs.npmjs.com/trusted-publishers#automatic-provenance-generation):
   > When you publish using trusted publishing, npm automatically generates and publishes [provenance attestations](https://docs.npmjs.com/generating-provenance-statements) for your package. This happens by default—you don't need to add the `--provenance` flag to your publish command.  