### PR TITLE
Bump actions & use Node.js 24

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: github/codeql-action/init@v3
         with:
           config-file: ./.github/codeql-config.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ jobs:
       id-token: write # to generate npm provenance statements and allow OIDC auth
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: npm
-          node-version: 20
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Release

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: npm
-          node-version: 22
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
@@ -57,9 +57,9 @@ jobs:
           - 24
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: npm
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
See https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/

The OIDC publishing requires npm 11.5.1 or later. The Node.js 24.8.0 has a higher npm ([11.6.0](https://nodejs.org/en/blog/release/v24.8.0)) bundled.