### PR TITLE
Revert to npm token for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,9 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: Set up OIDC for npm publish without NPM_TOKEN
+          # when semantic-release supports it
+          # See https://github.com/semantic-release/npm/issues/958
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release


### PR DESCRIPTION
Resolves #136

The release has failed https://github.com/simple-icons/svglint/actions/runs/18034881450/job/51319502864#step:5:35

`semantic-release` does not support publishing without token for now, see https://github.com/semantic-release/npm/issues/958

I've added my own granular `NPM_TOKEN` to repository secrets.