### PR TITLE
fix: rename default export `SVGLint`

### DIFF
--- a/src/svglint.js
+++ b/src/svglint.js
@@ -142,7 +142,7 @@ ${ast.source}`);
 	return new Linting(file, ast, config_.rules, config_.fixtures);
 }
 
-const svglint = {
+const SVGLint = {
 	/**
 	 * Lints a single SVG string.
 	 * The function returns before the Linting is finished.
@@ -190,5 +190,5 @@ const svglint = {
 	},
 };
 
-export default svglint;
+export default SVGLint;
 export {normalizeConfig};


### PR DESCRIPTION
When importing the default export, it's recommended to use the same name as the exported variable (cf. [_import-x/no-rename-default_](https://github.com/un-ts/eslint-plugin-import-x/blob/v4.17.1/docs/rules/no-rename-default.md)).

This package exports a variable named [`svglint`](https://github.com/simple-icons/svglint/blob/v4.2.1/src/svglint.js#L193). With the following file:

```javascript
import SVGLint from "svglint";

const linting = await SVGLint.lintSource("<svg>...</svg>", {
    // ... config object goes here
});

// ...
```

ESLint and _import-x/no-rename-default_ report this error:

> Caution: `index.js` has a default export `svglint`. This imports `svglint` as `SVGLint`. Check if you meant to write `import svglint from 'svglint'` instead.

---

With this pull request, we will be able to use the name `SVGLint`.