### PR TITLE
docs: Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ const config = {
 export default config;
 ```
 
-[*Selecting elements* on cheerio's documentation]: https://cheerio.js.org/docs/basics/selecting
-[`XMLValidator` of fast-xml-parser]: https://github.com/NaturalIntelligence/fast-xml-parser/blob/HEAD/docs/v4/4.XMLValidator.md
-[`Cheerio` object]: https://cheerio.js.org/docs/api/classes/Cheerio
+[*Selecting elements* on cheerio's documentation]: https://cheerio.js.org/docs/basics/selecting/
+[`XMLValidator` of fast-xml-parser]: https://github.com/NaturalIntelligence/fast-xml-parser/blob/HEAD/docs/v4%2C%20v5/4.XMLValidator.md
+[`Cheerio` object]: https://cheerio.js.org/docs/api/classes/cheerio/
 [htmlparser2]: https://feedic.com/htmlparser2/


### PR DESCRIPTION
Update links in README to fix CI [_Check links_](https://github.com/simple-icons/svglint/actions/runs/30475504224/job/90656085713#step:3:113).

- <https://cheerio.js.org/docs/basics/selecting> → <https://cheerio.js.org/docs/basics/selecting/> : Follow the redirect that adds a slash at the end.
- <https://github.com/NaturalIntelligence/fast-xml-parser/blob/HEAD/docs/v4/4.XMLValidator.md> → <https://github.com/NaturalIntelligence/fast-xml-parser/blob/HEAD/docs/v4%2C%20v5/4.XMLValidator.md> : The `v4` directory has been [renamed](https://github.com/NaturalIntelligence/fast-xml-parser/commit/3412fee64adf09fde8ce5e822d31ae051fdb860f#diff-37abf82f281d44f17fc92bc34d8ea1ed04b5fe7abe20e6ed05ac91731a642698) to `v4, v5`.
- <https://cheerio.js.org/docs/api/classes/Cheerio> → <https://cheerio.js.org/docs/api/classes/cheerio/> : The class name is written in lowercase.